### PR TITLE
Allow output during tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,7 @@
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-    beStrictAboutOutputDuringTests="true"
+    beStrictAboutOutputDuringTests="false"
     bootstrap="vendor/autoload.php"
     colors="true"
     executionOrder="random"


### PR DESCRIPTION
## What does this pull request do?

Allows output during PHPUnit tests.

## Why is this pull request needed?

Tests will fail for this project without this adjustment.

## How does this pull request work?

Sets `beStrictAboutOutputDuringTests` to false.
