### PR TITLE
Added ability to throttle display frequency

### DIFF
--- a/src/ProgressBar.php
+++ b/src/ProgressBar.php
@@ -13,11 +13,17 @@ final class ProgressBar
     /** Width of progress bar, in number of characters */
     private int $barWidth = 28;
 
+    /** Minimum time in seconds between consecutive refreshes of display */
+    private float $drawFrequency = 0.25;
+
     /** Character to display remaining progress in progress bar */
     private string $emptyBarCharacter = '.';
 
     /** Estimated time to finish in seconds */
     private int $estimatedTime = 0;
+
+    /** Timing of last display */
+    private float $lastDisplayTime = 0.0;
 
     /** Current progress in percentage */
     private int $percentage = 0;
@@ -256,6 +262,8 @@ final class ProgressBar
     {
         $this->startTime = time();
 
+        $this->lastDisplayTime = microtime(true);
+
         $this->hideCursor()
             ->display();
     }
@@ -266,7 +274,15 @@ final class ProgressBar
     public function tick(int $progress = 1): void
     {
         $this->setProgress($this->progress + $progress)
-            ->setEstimatedTime()
-            ->display();
+            ->setEstimatedTime();
+
+        /** Throttle refreshing of display for smoother animation  */
+        if ((microtime(true) - $this->lastDisplayTime) < $this->drawFrequency) {
+            return;
+        }
+
+        $this->lastDisplayTime = time();
+
+        $this->display();
     }
 }


### PR DESCRIPTION
## What does this pull request do?

Adds ability to throttle display frequency. This provides a smoother animation when the progress bar is running.

## Why is this pull request needed?

The animation of the progress bar sometimes progresses too fast and affects the animation of the progress bar in a disturbing way.

## How does this pull request work?

It saves a `microtime()` float between concurrent displays and only allows a display to be refreshed if there is at least 0.25 seconds (current default) between concurrent displays.
