### PR TITLE
Implicit conversion from float-string to int is deprecated

### DIFF
--- a/src/ProgressBar.php
+++ b/src/ProgressBar.php
@@ -225,7 +225,8 @@ final class ProgressBar
      */
     private function setPercentage(): void
     {
-        $this->percentage = number_format(($this->progress / $this->maxProgress) * 100, 2);
+        $percentage = ($this->progress / $this->maxProgress) * 100;
+        $this->percentage = number_format(round($percentage), 2);
     }
 
     /**


### PR DESCRIPTION
See https://php.watch/versions/8.1/deprecate-implicit-conversion-incompatible-float-string