### PR TITLE
Add full support for floating values without implicit conversion

### DIFF
--- a/src/ProgressBar.php
+++ b/src/ProgressBar.php
@@ -35,12 +35,12 @@ final class ProgressBar
      * Initialize and set progress and maxProgress when available.
      * Use separate setProgress() and setMaxProgress() methods when undetermined during initialization.
      *
-     * @param int $progress Current progress
-     * @param int $maxProgress Maximum progress
+     * @param int|float $progress Current progress
+     * @param int|float $maxProgress Maximum progress
      */
     public function __construct(
-        private int $progress = 0,
-        private int $maxProgress = 100,
+        private int|float $progress = 0,
+        private int|float $maxProgress = 100,
     ) {
         $this->startTime = time();
 
@@ -72,11 +72,11 @@ final class ProgressBar
         echo sprintf(
             '%s%s/%d [%s%s] %s%%',
             "\r",
-            str_pad(string: $this->progress, length: strlen((string) $this->maxProgress), pad_type: STR_PAD_LEFT),
-            $this->maxProgress,
+            str_pad(string: $this->getProgress(), length: strlen((string) $this->getMaxProgress()), pad_type: STR_PAD_LEFT),
+            $this->getMaxProgress(),
             str_repeat($this->barCharacter, $barCompleteWidth),
             str_repeat($this->emptyBarCharacter, $barIncompleteWidth),
-            str_pad(string: $this->percentage, length: 3, pad_type: STR_PAD_LEFT)
+            str_pad(string: $this->getPercentage(), length: 3, pad_type: STR_PAD_LEFT)
         );
 
         /** Remove estimated time from display when done */
@@ -116,7 +116,7 @@ final class ProgressBar
      */
     public function getMaxProgress(): int
     {
-        return $this->maxProgress;
+        return round($this->maxProgress);
     }
 
     /**
@@ -132,7 +132,7 @@ final class ProgressBar
      */
     public function getProgress(): int
     {
-        return $this->progress;
+        return round($this->progress);
     }
 
     /**
@@ -213,7 +213,7 @@ final class ProgressBar
     /**
      * Manually adjust the maxProgress parameter when undetermined or changed.
      */
-    public function setMaxProgress(int $maxProgress): ProgressBar
+    public function setMaxProgress(int|float $maxProgress): ProgressBar
     {
         $this->maxProgress = max(1, $maxProgress);
 
@@ -232,7 +232,7 @@ final class ProgressBar
     /**
      * Manually adjust the progress parameter.
      */
-    public function setProgress(int $progress): ProgressBar
+    public function setProgress(int|float $progress): ProgressBar
     {
         /** Increase maxProgress if progress unexpectedly gets higher than progress */
         if ($progress > $this->maxProgress) {

--- a/tests/ProgressBarTest.php
+++ b/tests/ProgressBarTest.php
@@ -73,6 +73,28 @@ class ProgressBarTest extends TestCase
     /**
      * @test
      */
+    public function it_can_handle_floating_integers()
+    {
+        $progressBar = new ProgressBar(progress: 1.111, maxProgress: 9.999);
+        $this->assertEquals(1, $progressBar->getProgress());
+        $this->assertEquals(10, $progressBar->getMaxProgress());
+
+        $progressBar->setMaxProgress('99.999');
+        $this->assertEquals(100, $progressBar->getMaxProgress());
+
+        $progressBar->setProgress(9.999);
+        $this->assertEquals(10, $progressBar->getProgress());
+
+        $progressBar->start();
+        $progressBar->tick();
+        $this->assertEquals(11, $progressBar->getProgress());
+
+        $this->assertEquals(11, $progressBar->getPercentage());
+    }
+
+    /**
+     * @test
+     */
     public function it_can_iterate_through_array()
     {
         $iteration = [


### PR DESCRIPTION
## What does this pull request do?

This PR adds a full fix for deprecation notices about implicit conversions of floating values losing precision. #14 was a partial fix for this issue.

## Why is this pull request needed?

Implicit conversion of floating values will trigger deprecation notices in PHP 8.1 or newer.

## How does this pull request work?

This PR adds explicit conversion of floating values where applicable.
