### PR TITLE
Fix non-countable warning for iterable values

### DIFF
--- a/src/ProgressBar.php
+++ b/src/ProgressBar.php
@@ -161,7 +161,7 @@ final class ProgressBar
     /**
      * Iterate through countable variables such as an array.
      */
-    public function iterate(iterable $iterable): iterable
+    public function iterate(\Countable|iterable $iterable): iterable
     {
         $this->setMaxProgress(is_countable($iterable) ? count($iterable) : 0);
 


### PR DESCRIPTION
## What does this pull request do?

This PR fixes a warning about the `iterate()` method not being compatible with `count()` which is needed for iterating over arrays and other iterable data.
