### PR TITLE
Add support for PHP 8.3 tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [8.2, 8.1, 8.0]
+                php: [8.3, 8.2, 8.1, 8.0]
                 os: [ubuntu-latest, windows-latest]
 
         name: PHP ${{ matrix.php }} - ${{ matrix.os }}


### PR DESCRIPTION
## What does this pull request do?

This PR enables automated tests for the latest PHP 8.3 version.

## Why is this pull request needed?

This PR is needed to ensure future changes will also work in applications running PHP 8.3
