### PR TITLE
Fix 24 hour limit when displaying estimated time

### DIFF
--- a/src/ProgressBar.php
+++ b/src/ProgressBar.php
@@ -82,10 +82,7 @@ final class ProgressBar
         /** Remove estimated time from display when done */
         if ($this->percentage < 100) {
             echo sprintf(
-                ' (%s)',
-                (
-                    $this->estimatedTime < 86400 ? gmdate('H:i:s', $this->estimatedTime) : '>23:59:59'
-                )
+                ' (%s)', gmdate('H:i:s', $this->estimatedTime)
             );
         }
 

--- a/src/ProgressBar.php
+++ b/src/ProgressBar.php
@@ -82,7 +82,8 @@ final class ProgressBar
         /** Remove estimated time from display when done */
         if ($this->percentage < 100) {
             echo sprintf(
-                ' (%s)', gmdate('H:i:s', $this->estimatedTime)
+                ' (%s)',
+                gmdate('H:i:s', $this->estimatedTime)
             );
         }
 

--- a/src/ProgressBar.php
+++ b/src/ProgressBar.php
@@ -82,10 +82,10 @@ final class ProgressBar
         /** Remove estimated time from display when done */
         if ($this->percentage < 100) {
             echo sprintf(
-                ' (%s)',
-                (
-                    $this->estimatedTime < 86400 ? gmdate('H:i:s', $this->estimatedTime) : '>23:59:59'
-                )
+                ' (%02d:%02d:%02d)',
+                floor($this->estimatedTime / 3600),
+                floor($this->estimatedTime / 60) % 60,
+                floor($this->estimatedTime) % 60
             );
         }
 


### PR DESCRIPTION
## What does this pull request do?

This PR removes the limit on displaying an estimated time larger than 24 hours with a static ">23:59:59" message.

## Why is this pull request needed?

As requested in issue #19 

## How does this pull request work?

It swaps out `gmdate` for calculating times since it won't work with estimated times longer than 24 hours. This was the reason why the limit was implemented in the first place.