### PR TITLE
Fix possible division by zero error

### DIFF
--- a/src/ProgressBar.php
+++ b/src/ProgressBar.php
@@ -286,6 +286,7 @@ final class ProgressBar
     {
         if ($progress == 0 && $this->maxProgressIsZero) {
             $this->finish();
+
             return;
         }
 

--- a/src/ProgressBar.php
+++ b/src/ProgressBar.php
@@ -239,7 +239,7 @@ final class ProgressBar
             $this->setMaxProgress($progress);
         }
 
-        $this->progress = max(0, $progress);
+        $this->progress = max(1, $progress);
 
         $this->setPercentage();
 

--- a/src/ProgressBar.php
+++ b/src/ProgressBar.php
@@ -32,6 +32,12 @@ final class ProgressBar
     private int $startTime;
 
     /**
+     * Indicator whether maxProgress was truly set as zero.
+     * MaxProgress must always be at least one to be displayed.
+     */
+    private bool $maxProgressIsZero = false;
+
+    /**
      * Initialize and set progress and maxProgress when available.
      * Use separate setProgress() and setMaxProgress() methods when undetermined during initialization.
      *
@@ -204,7 +210,7 @@ final class ProgressBar
         $this->estimatedTime = round(
             (
                 time() - $this->startTime
-            ) / $this->progress * ($this->maxProgress - $this->progress)
+            ) / max(1, $this->progress) * ($this->maxProgress - $this->progress)
         );
 
         return $this;
@@ -215,6 +221,10 @@ final class ProgressBar
      */
     public function setMaxProgress(int|float $maxProgress): ProgressBar
     {
+        if ($maxProgress == 0) {
+            $this->maxProgressIsZero = true;
+        }
+
         $this->maxProgress = max(1, $maxProgress);
 
         return $this;
@@ -239,7 +249,7 @@ final class ProgressBar
             $this->setMaxProgress($progress);
         }
 
-        $this->progress = max(1, $progress);
+        $this->progress = max(0, $progress);
 
         $this->setPercentage();
 
@@ -274,6 +284,11 @@ final class ProgressBar
      */
     public function tick(int $progress = 1): void
     {
+        if ($progress == 0 && $this->maxProgressIsZero) {
+            $this->finish();
+            return;
+        }
+
         $this->setProgress($this->progress + $progress)
             ->setEstimatedTime();
 

--- a/tests/ProgressBarTest.php
+++ b/tests/ProgressBarTest.php
@@ -155,8 +155,10 @@ class ProgressBarTest extends TestCase
     public function it_can_gracefully_handle_zero_progress()
     {
         $progressBar = new ProgressBar(maxProgress: 0);
+        $this->assertEquals(1, $progressBar->getMaxProgress());
 
         $progressBar->tick(0);
+        $this->assertEquals(1, $progressBar->getProgress());
 
         $this->assertEquals(100, $progressBar->getPercentage());
     }

--- a/tests/ProgressBarTest.php
+++ b/tests/ProgressBarTest.php
@@ -148,4 +148,16 @@ class ProgressBarTest extends TestCase
 
         $this->assertEquals(1, $progressBar->getMaxProgress());
     }
+
+    /**
+     * @test
+     */
+    public function it_can_gracefully_handle_zero_progress()
+    {
+        $progressBar = new ProgressBar(maxProgress: 0);
+
+        $progressBar->tick(0);
+
+        $this->assertEquals(100, $progressBar->getPercentage());
+    }
 }


### PR DESCRIPTION
## What does this pull request do?

This PR fixes a possible "division by zero" error when explicitly setting zero as progress when the currently made progress is also zero.

Fixes #21

## Why is this pull request needed?

This library should gracefully finish the progress bar instead of displaying a PHP-specific error.

## How does this pull request work?

Progress is now explicitly set to at least one during the remaining time calculation. Furthermore a new boolean value is placed to track whether `maxProgress` was meant to be zero as `maxProgress` itself cannot be zero when displaying the progress bar.
