### PR TITLE
Fix misleading progress indicators with zero ticks

### DIFF
--- a/src/ProgressBar.php
+++ b/src/ProgressBar.php
@@ -225,7 +225,7 @@ final class ProgressBar
             $this->maxProgressIsZero = true;
         }
 
-        $this->maxProgress = max(1, $maxProgress);
+        $this->maxProgress = max(0, $maxProgress);
 
         return $this;
     }
@@ -235,6 +235,12 @@ final class ProgressBar
      */
     private function setPercentage(): void
     {
+        // Handle the "0 of 0" case as fully complete (100%) without division by zero
+        if ($this->maxProgress == 0) {
+            $this->percentage = 100;
+            return;
+        }
+
         $percentage = ($this->progress / $this->maxProgress) * 100;
         $this->percentage = number_format(round($percentage), 2);
     }

--- a/tests/ProgressBarTest.php
+++ b/tests/ProgressBarTest.php
@@ -146,7 +146,7 @@ class ProgressBarTest extends TestCase
         $progressBar = new ProgressBar();
         $progressBar->setMaxProgress(-1);
 
-        $this->assertEquals(1, $progressBar->getMaxProgress());
+        $this->assertEquals(0, $progressBar->getMaxProgress());
     }
 
     /**
@@ -155,10 +155,10 @@ class ProgressBarTest extends TestCase
     public function it_can_gracefully_handle_zero_progress()
     {
         $progressBar = new ProgressBar(maxProgress: 0);
-        $this->assertEquals(1, $progressBar->getMaxProgress());
+        $this->assertEquals(0, $progressBar->getMaxProgress());
 
         $progressBar->tick(0);
-        $this->assertEquals(1, $progressBar->getProgress());
+        $this->assertEquals(0, $progressBar->getProgress());
 
         $this->assertEquals(100, $progressBar->getPercentage());
     }


### PR DESCRIPTION
## What does this pull request do?

This PR fixes misleading progress indicators when both `progress` and `maxProgress` are equal to zero. Originally both values would reset to one to avoid a DivisionByZero error (#22).

Fixes #25

## Why is this pull request needed?

This new behavior will show the correct progress values in situations where a programmatic loop has nothing to tick through.

This PR will be released within a new minor version since it changes to behavior of `progress` and `maxProgress` for anyone who explicitly checks these values in their code.

```php
$progressBar = new ProgressBar(progress: 0, maxProgress: 0);
$progressBar->start();

while ($i <= 10) {
  continue; /* nothing to tick */
}

$progressBar->finish();

/* previous behavior */
1/1 [############################] 100% 

/* new behavior */
0/0 [############################] 100% 
```

## How does this pull request work?

Values for `progress` and `maxProgress` no longer reset to one when both values are zero by default. When both values are zero, the percentage is automatically set to 100% without any calculation to avoid a DivisionByZero error.
